### PR TITLE
Namespace stream operators

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         brew install bison flex
-        echo "::add-path::/usr/local/opt/bison/bin"
-        echo "::add-path::/usr/local/opt/flex/bin"
+        echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
+        echo "/usr/local/opt/flex/bin" >> $GITHUB_PATH
     - uses: actions/cache@v2
       if: matrix.os == 'windows-latest'
       with:

--- a/examples/interpreter/primitives.hpp
+++ b/examples/interpreter/primitives.hpp
@@ -124,8 +124,6 @@ public:
 
 };
 
-} // namespace primitives
-
 /**
  * Stream << overload for source location objects.
  */
@@ -133,3 +131,5 @@ inline std::ostream& operator<<(std::ostream& os, const primitives::SourceLocati
     os << object.filename << ":" << object.line << ":" << object.column;
     return os;
 }
+
+} // namespace primitives

--- a/generator/tree-gen-cpp.cpp
+++ b/generator/tree-gen-cpp.cpp
@@ -1234,6 +1234,15 @@ void generate(
     source << "    this->visit_internal(visitor);" << std::endl;
     source << "}" << std::endl << std::endl;
 
+    // Overload the stream write operator.
+    format_doc(header, "Stream << overload for tree nodes (writes debug dump).");
+    header << "std::ostream &operator<<(std::ostream &os, const Node &object);" << std::endl << std::endl;
+    format_doc(source, "Stream << overload for tree nodes (writes debug dump).");
+    source << "std::ostream &operator<<(std::ostream &os, const Node &object) {" << std::endl;
+    source << "    const_cast<Node&>(object).dump(os);" << std::endl;
+    source << "    return os;" << std::endl;
+    source << "}" << std::endl << std::endl;
+
     // Close the namespaces.
     for (auto name_it = specification.namespaces.rbegin(); name_it != specification.namespaces.rend(); name_it++) {
         header << "} // namespace " << *name_it << std::endl;
@@ -1241,19 +1250,6 @@ void generate(
     }
     header << std::endl;
     source << std::endl;
-
-    // Overload the stream write operator.
-    std::string name_space = "";
-    for (auto &name : specification.namespaces) {
-        name_space += "::" + name;
-    }
-    format_doc(header, "Stream << overload for tree nodes (writes debug dump).");
-    header << "std::ostream& operator<<(std::ostream& os, const " << name_space << "::Node& object);" << std::endl << std::endl;
-    format_doc(source, "Stream << overload for tree nodes (writes debug dump).");
-    source << "std::ostream& operator<<(std::ostream& os, const " << name_space << "::Node& object) {" << std::endl;
-    source << "    const_cast<" << name_space << "::Node&>(object).dump(os);" << std::endl;
-    source << "    return os;" << std::endl;
-    source << "}" << std::endl << std::endl;
 
 }
 

--- a/include/tree-cbor.hpp
+++ b/include/tree-cbor.hpp
@@ -544,5 +544,5 @@ public:
 
 };
 
-}
-}
+} // namespace cbor
+} // namespace tree

--- a/include/tree-compat.hpp
+++ b/include/tree-compat.hpp
@@ -15,4 +15,4 @@ typedef long long signed_size_t;
 typedef ssize_t signed_size_t;
 #endif
 
-}
+} // namespace tree


### PR DESCRIPTION
Apparently, operators operating on things from different namespaces don't have to be declared in the global namespace due to dark magic and reasons, and in fact C++ prevents you from using them in that case in some circumstances. Also fixes some missing end-of.namespace comments.