### PR TITLE
tree-gen classes can now dump to JSON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,12 +189,6 @@ add_executable(
     "${CMAKE_CURRENT_SOURCE_DIR}/generator/tree-gen-cpp.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/generator/tree-gen-python.cpp"
 )
-if(MSVC)
-    target_compile_options(tree-gen PRIVATE
-        /D_CRT_NONSTDC_NO_DEPRECATE
-        /D_CRT_SECURE_NO_WARNINGS
-    )
-endif()
 
 target_include_directories(
     tree-gen
@@ -206,9 +200,36 @@ target_link_libraries(tree-gen
     PRIVATE fmt::fmt
 )
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+    target_compile_options(tree-gen PRIVATE
+        -Wall -Wextra -Werror -Wfatal-errors
+        -fPIC
+        -Wno-error=deprecated-declarations
+        -Wno-error=restrict
+        -Wno-error=sign-compare
+    )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    target_compile_options(tree-gen PRIVATE
+        -Wall -Wextra -Werror -Wfatal-errors
+        -fPIC
+        -Wno-error=sign-compare
+        -Wno-error=unused-private-field
+        -Wno-error=unused-but-set-variable
+    )
+elseif(MSVC)
+    target_compile_options(tree-gen PRIVATE
+        /W3 /w34996  # not using /WX at the moment because the flex generated code has some warnings
+        /D_CRT_NONSTDC_NO_DEPRECATE
+        /D_CRT_SECURE_NO_WARNINGS
+        /D_UNICODE /DUNICODE
+        /diagnostics:column /EHsc /FC /fp:precise /Gd /GS /MP /sdl /utf-8 /Zc:inline
+    )
+else()
+    message(SEND_ERROR "Unknown compiler!")
+endif()
+
 # Utility function for generating a C++-only tree with tree-gen.
 function(generate_tree TREE HDR SRC)
-
     # Get the directory for the header file and make sure it exists.
     get_filename_component(HDR_DIR "${HDR}" PATH)
     file(MAKE_DIRECTORY "${HDR_DIR}")
@@ -223,12 +244,10 @@ function(generate_tree TREE HDR SRC)
         OUTPUT "${HDR}" "${SRC}"
         DEPENDS "${TREE}" tree-gen
     )
-
 endfunction()
 
 # Utility function for generating a C++ and Python tree with tree-gen.
 function(generate_tree_py TREE HDR SRC PY)
-
     # Get the directory for the header file and make sure it exists.
     get_filename_component(HDR_DIR "${HDR}" PATH)
     file(MAKE_DIRECTORY "${HDR_DIR}")
@@ -247,7 +266,6 @@ function(generate_tree_py TREE HDR SRC PY)
         OUTPUT "${HDR}" "${SRC}" "${PY}"
         DEPENDS "${TREE}" tree-gen
     )
-
 endfunction()
 
 

--- a/examples/directory/main.cpp
+++ b/examples/directory/main.cpp
@@ -255,6 +255,11 @@ int main() {
     system2->dump();
     MARKER
 
+    // Testing the JSON dump
+    system2->dump_json();
+    std::printf("\n");
+    MARKER
+
     // Note that equality for two link edges is satisfied only if they point to
     // the exact same node. That's not the case for the links in our two
     // entirely separate trees, so the two trees register as unequal.

--- a/examples/interpreter/main.cpp
+++ b/examples/interpreter/main.cpp
@@ -189,6 +189,11 @@ int main() {
     tree->dump();
     MARKER
 
+    // Testing the JSON dump
+    tree->dump_json();
+    std::printf("\n");
+    MARKER
+
     // Note that we can still use these pointers despite ownership having been
     // passed to the node objects because they refer to the same piece of
     // memory. In practice, though, you would do this during the parser actions,
@@ -317,7 +322,7 @@ int main() {
     ASSERT(expr->visit(eval) == 14);
     MARKER
 
-    // If we wouldn't have implemented ``visit_node()``, the
+    // If we hadn't implemented ``visit_node()``, the
     // ``RvalueEvaluator eval{};`` line would break, as RvalueEvaluator would
     // be an abstract class because of it. And while the above may look pretty
     // complete, it is in fact not:

--- a/generator/parser.y
+++ b/generator/parser.y
@@ -136,8 +136,8 @@ Root            :                                                               
 %%
 
 void yyerror(YYLTYPE* yyllocp, yyscan_t unused, tree_gen::Specification &specification, const char* msg) {
-    (void)unused;
-    (void)specification;
+    (void) unused;
+    (void) specification;
     std::cerr << "Parse error at " << ":"
               << yyllocp->first_line << ":" << yyllocp->first_column << ".."
               << yyllocp->last_line << ":" << yyllocp->last_column

--- a/generator/tree-gen-cpp.cpp
+++ b/generator/tree-gen-cpp.cpp
@@ -405,7 +405,7 @@ void generate_node_class(
         format_doc(source, doc);
         source << "void " << node.title_case_name;
         source << "::find_reachable(" << support_ns << "::base::PointerMap &map) const {" << std::endl;
-        source << "    (void)map;" << std::endl;
+        source << "    (void) map;" << std::endl;
         for (auto &field : all_fields) {
             auto type = (field.type == Prim) ? field.ext_type : field.type;
             switch (type) {
@@ -429,7 +429,7 @@ void generate_node_class(
         format_doc(source, doc);
         source << "void " << node.title_case_name;
         source << "::check_complete(const " << support_ns << "::base::PointerMap &map) const {" << std::endl;
-        source << "    (void)map;" << std::endl;
+        source << "    (void) map;" << std::endl;
         if (node.is_error_marker) {
             source << "    throw " << support_ns << "::base::NotWellFormed(\"" << node.title_case_name << " error node in tree\");" << std::endl;
         } else {
@@ -573,7 +573,7 @@ void generate_node_class(
             source << "    " << support_ns << "::cbor::MapWriter &map," << std::endl;
             source << "    const " << support_ns << "::base::PointerMap &ids" << std::endl;
             source << ") const {" << std::endl;
-            source << "    (void)ids;" << std::endl;
+            source << "    (void) ids;" << std::endl;
             source << "    map.append_string(\"@t\", \"" << node.title_case_name << "\");" << std::endl;
             bool first = true;
             for (const auto &field : all_fields) {
@@ -600,7 +600,7 @@ void generate_node_class(
             format_doc(source, "Deserializes the given node.");
             source << "std::shared_ptr<" << node.title_case_name << "> ";
             source << node.title_case_name << "::deserialize(const " << support_ns << "::cbor::MapReader &map, " << support_ns << "::base::IdentifierMap &ids) {" << std::endl;
-            source << "    (void)ids;" << std::endl;
+            source << "    (void) ids;" << std::endl;
             source << "    auto type = map.at(\"@t\").as_string();" << std::endl;
             source << "    if (type != \"" << node.title_case_name << "\") {" << std::endl;
             source << "        throw std::runtime_error(\"Schema validation failed: unexpected node type \" + type);" << std::endl;
@@ -685,7 +685,7 @@ void generate_visitor_base_class(
     std::ofstream &source,
     Nodes &nodes
 ) {
-    (void)source;
+    (void) source;
 
     // Print class header.
     format_doc(
@@ -799,7 +799,7 @@ void generate_visitor_class(
     format_doc(source, "Internal visitor function for nodes of any type.");
     source << "template <>" << std::endl;
     source << "void Visitor<void>::raw_visit_node(Node &node, void *retval) {" << std::endl;
-    source << "    (void)retval;" << std::endl;
+    source << "    (void) retval;" << std::endl;
     source << "    this->visit_node(node);" << std::endl;
     source << "}" << std::endl << std::endl;
 
@@ -825,7 +825,7 @@ void generate_visitor_class(
         source << "template <>" << std::endl;
         source << "void Visitor<void>::raw_visit_" << node->snake_case_name;
         source << "(" << node->title_case_name << " &node, void *retval) {" << std::endl;
-        source << "    (void)retval;" << std::endl;
+        source << "    (void) retval;" << std::endl;
         source << "    this->visit_" << node->snake_case_name << "(node);" << std::endl;
         source << "}" << std::endl << std::endl;
     }
@@ -923,7 +923,7 @@ void generate_dumper_class(
     header << "    void visit_node(Node &node) override;" << std::endl;
     format_doc(source, "Dumps a `Node`.");
     source << "void Dumper::visit_node(Node &node) {" << std::endl;
-    source << "    (void)node;" << std::endl;
+    source << "    (void) node;" << std::endl;
     source << "    write_indent();" << std::endl;
     source << "    out << \"!Node()\" << std::endl;" << std::endl;
     source << "}" << std::endl << std::endl;
@@ -1111,7 +1111,7 @@ void generate_json_dumper_class(
     format_doc(source, "JSON dumps a `Node`.");
     fmt::print(source,
         "void JsonDumper::visit_node(Node &node) {{\n"
-        "    (void)node;\n"
+        "    (void) node;\n"
         "    out << \"!Node()\";\n"
         "}}\n\n");
 
@@ -1128,7 +1128,7 @@ void generate_json_dumper_class(
         // If the node has no attributes, the code that does the JSON dump won't reference the node parameter
         // So (void) it so that we don't get an unused parameter compiler error
         if (source_location.empty() && attributes.empty()) {
-            fmt::print(source, "    (void)node;\n");
+            fmt::print(source, "    (void) node;\n");
         }
         fmt::print(source,
             R"(    out << "{{";)""\n"

--- a/generator/tree-gen-cpp.cpp
+++ b/generator/tree-gen-cpp.cpp
@@ -1123,13 +1123,18 @@ void generate_json_dumper_class(
         fmt::print(header, "    void visit_{}({} &node) override;\n\n",
             node->snake_case_name, node->title_case_name);
         format_doc(source, doc);
-        fmt::print(source,
-            R"(void JsonDumper::visit_{0}({1} &node) {{)""\n"
-            R"(    out << "{{";)""\n"
-            R"(    out << "\"{1}\":";)""\n",
-            node->snake_case_name,
-            node->title_case_name);
         auto attributes = node->all_fields();
+        fmt::print(source, "void JsonDumper::visit_{0}({1} &node) {{\n",
+            node->snake_case_name, node->title_case_name);
+        // If the node has no attributes, the code that does the JSON dump won't reference the node parameter
+        // So (void) it so that we don't get an unused parameter compiler error
+        if (source_location.empty() && attributes.empty()) {
+            fmt::print(source, "    (void){0};\n", node->snake_case_name);
+        }
+        fmt::print(source,
+            R"(    out << "{{";)""\n"
+            R"(    out << "\"{0}\":";)""\n",
+            node->title_case_name);
         fmt::print(source, "    out << \"{{\";\n");
         bool first_attrib = true;
         if (!source_location.empty()) {

--- a/generator/tree-gen-cpp.cpp
+++ b/generator/tree-gen-cpp.cpp
@@ -9,6 +9,7 @@
 #include <fmt/ostream.h>
 #include <fstream>
 #include <iostream>
+#include <string>
 #include <unordered_set>
 
 namespace tree_gen {
@@ -684,7 +685,7 @@ void generate_visitor_base_class(
     std::ofstream &source,
     Nodes &nodes
 ) {
-    (void) source;
+    (void)source;
 
     // Print class header.
     format_doc(
@@ -887,7 +888,6 @@ void generate_dumper_class(
     std::string &source_location,
     std::string &support_ns
 ) {
-
     // Print class header.
     format_doc(header, "Visitor class that debug-dumps a tree to a stream");
     header << "class Dumper : public RecursiveVisitor {" << std::endl;
@@ -1090,7 +1090,6 @@ void generate_json_dumper_class(
     Nodes &nodes,
     std::string &source_location
 ) {
-
     // Print class header.
     format_doc(header, "Visitor class that JSON dumps a tree to a stream");
     fmt::print(header,
@@ -1135,12 +1134,12 @@ void generate_json_dumper_class(
             R"(    out << "{{";)""\n"
             R"(    out << "\"{0}\":";)""\n",
             node->title_case_name);
-        fmt::print(source, "    out << \"{{\";\n");
+        fmt::print(source, R"(    out << "{{";)""\n");
         bool first_attrib = true;
         if (!attributes.empty()) {
             for (auto &attrib : attributes) {
                 if (!first_attrib) {
-                    fmt::print(source, "    out << \",\";\n");
+                    fmt::print(source, R"(    out << ",";)""\n");
                 }
                 first_attrib = false;
                 switch (attrib.ext_type) {
@@ -1153,8 +1152,7 @@ void generate_json_dumper_class(
                             R"(        out << "\"{0}\":\"{1}\"";)""\n",
                             attrib.name,
                             (attrib.ext_type == One || attrib.ext_type == Link) ? "!MISSING" : "-");
-                        fmt::print(source,
-                            "    }} else {{\n");
+                        fmt::print(source, "    }} else {{\n");
                         if (attrib.ext_type == Link || attrib.ext_type == OptLink) {
                             fmt::print(source,
                                 "        if (!in_link) {{\n"
@@ -1191,37 +1189,34 @@ void generate_json_dumper_class(
                                 R"(      node.{0}.visit(*this);)""\n",
                                 attrib.name);
                         }
-                        fmt::print(source,
-                            "    }}\n");
+                        fmt::print(source, "    }}\n");
                         break;
-
                     case Any:
                     case Many:
                         fmt::print(source,
-                            "    if (node.{0}.empty()) {{\n"
+                            R"(    if (node.{0}.empty()) {{)""\n"
                             R"(        out << "\"{0}\":\"{1}\"";)""\n"
-                            "    }} else {{\n"
+                            R"(    }} else {{)""\n"
                             R"(        out << "\"{0}\":[";)""\n"
-                            "        bool first_element = true;\n"
-                            "        for (auto &sptr : node.{0}) {{\n"
-                            "            if (first_element) {{\n"
-                            "                first_element = false;\n"
-                            "            }} else {{\n"
-                            "                out << \",\";\n"
-                            "            }}\n"
-                            "            if (!sptr.empty()) {{\n"
-                            "                {2}\n"
-                            "            }} else {{\n"
-                            "                out << \"!NULL\";\n"
-                            "            }}\n"
-                            "        }}\n"
-                            "        out << \"]\";\n"
-                            "    }}\n",
+                            R"(        bool first_element = true;)""\n"
+                            R"(        for (auto &sptr : node.{0}) {{)""\n"
+                            R"(            if (first_element) {{)""\n"
+                            R"(                first_element = false;)""\n"
+                            R"(            }} else {{)""\n"
+                            R"(                out << ",";)""\n"
+                            R"(            }})""\n"
+                            R"(            if (!sptr.empty()) {{)""\n"
+                            R"(                {2};)""\n"
+                            R"(            }} else {{)""\n"
+                            R"(                out << "!NULL";)""\n"
+                            R"(            }})""\n"
+                            R"(        }})""\n"
+                            R"(        out << "]";)""\n"
+                            R"(    }})""\n",
                             attrib.name,
                             (attrib.ext_type == Many) ? "!MISSING" : "[]",
-                            (attrib.type == Prim) ? "sptr->dump_json(out);" : "sptr->visit(*this);");
+                            (attrib.type == Prim) ? "sptr->dump_json(out)" : "sptr->visit(*this)");
                         break;
-
                     case Prim:
                         fmt::print(source, R"(    out << "\"{0}\":\"" << node.{0} << "\"";)""\n", attrib.name);
                         break;
@@ -1232,16 +1227,16 @@ void generate_json_dumper_class(
         if (!source_location.empty()) {
             fmt::print(source, "    if (auto loc = node.get_annotation_ptr<{}>()) {{\n", source_location);
             if (!attributes.empty()) {
-                fmt::print(source, "    out << \",\";\n");
+                fmt::print(source, R"(        out << ",";)""\n");
             }
             fmt::print(source,
-                   R"(        out << "\"source_location\":\"" << *loc << "\"";)""\n"
-                   R"(    }})""\n");
+               R"(        out << "\"source_location\":\"" << *loc << "\"";)""\n"
+               R"(    }})""\n");
         }
         fmt::print(source, R"(    out << "}}";)""\n");
         fmt::print(source,
-            "    out << \"}}\";\n"
-            "}}\n\n");
+            R"(    out << "}}";)""\n"
+            R"(}})""\n\n");
     }
 
     fmt::print(header, "}};\n\n");

--- a/generator/tree-gen-cpp.cpp
+++ b/generator/tree-gen-cpp.cpp
@@ -1123,13 +1123,18 @@ void generate_json_dumper_class(
         fmt::print(header, "    void visit_{}({} &node) override;\n\n",
             node->snake_case_name, node->title_case_name);
         format_doc(source, doc);
-        fmt::print(source,
-            R"(void JsonDumper::visit_{0}({1} &node) {{)""\n"
-            R"(    out << "{{";)""\n"
-            R"(    out << "\"{1}\":";)""\n",
-            node->snake_case_name,
-            node->title_case_name);
         auto attributes = node->all_fields();
+        fmt::print(source, R"(void JsonDumper::visit_{0}({1} &node) {{)""\n",
+            node->snake_case_name, node->title_case_name);
+        // If the node has no attributes, the code that does the JSON dump won't reference the node parameter
+        // So (void) it so that we don't get an unused parameter compiler error
+        if (source_location.empty() && attributes.empty()) {
+            fmt::print(source, R"(    out << "(void){0}";)""\n", node->snake_case_name);
+        }
+        fmt::print(source,
+            R"(    out << "{{";)""\n"
+            R"(    out << "\"{0}\":";)""\n",
+            node->title_case_name);
         fmt::print(source, "    out << \"{{\";\n");
         bool first_attrib = true;
         if (!source_location.empty()) {

--- a/generator/tree-gen-cpp.cpp
+++ b/generator/tree-gen-cpp.cpp
@@ -684,6 +684,7 @@ void generate_visitor_base_class(
     std::ofstream &source,
     Nodes &nodes
 ) {
+    (void) source;
 
     // Print class header.
     format_doc(
@@ -727,7 +728,6 @@ void generate_visitor_class(
     std::ofstream &source,
     Nodes &nodes
 ) {
-
     // Print class header.
     format_doc(
         header,
@@ -828,7 +828,6 @@ void generate_visitor_class(
         source << "    this->visit_" << node->snake_case_name << "(node);" << std::endl;
         source << "}" << std::endl << std::endl;
     }
-
 }
 
 /**
@@ -1089,8 +1088,7 @@ void generate_json_dumper_class(
     std::ofstream &header,
     std::ofstream &source,
     Nodes &nodes,
-    std::string &source_location,
-    std::string &support_ns
+    std::string &source_location
 ) {
 
     // Print class header.
@@ -1473,7 +1471,7 @@ void generate(
     generate_visitor_class(header, source, nodes);
     generate_recursive_visitor_class(header, source, nodes);
     generate_dumper_class(header, source, nodes, specification.source_location, specification.support_namespace);
-    generate_json_dumper_class(header, source, nodes, specification.source_location, specification.support_namespace);
+    generate_json_dumper_class(header, source, nodes, specification.source_location);
 
     // Generate the templated visit method and its specialization for void
     // return type.

--- a/generator/tree-gen-cpp.cpp
+++ b/generator/tree-gen-cpp.cpp
@@ -1226,7 +1226,7 @@ void generate_json_dumper_class(
                         break;
 
                     case Prim:
-                        fmt::print(source, R"(    out << "\"{0}\":\"{0}\"";)""\n", attrib.name);
+                        fmt::print(source, R"(    out << "\"{0}\":\"" << node.{0} << "\"";)""\n", attrib.name);
                         break;
 
                 }

--- a/generator/tree-gen-cpp.cpp
+++ b/generator/tree-gen-cpp.cpp
@@ -1129,7 +1129,7 @@ void generate_json_dumper_class(
         // If the node has no attributes, the code that does the JSON dump won't reference the node parameter
         // So (void) it so that we don't get an unused parameter compiler error
         if (source_location.empty() && attributes.empty()) {
-            fmt::print(source, "    (void){0};\n", node->snake_case_name);
+            fmt::print(source, "    (void)node;\n");
         }
         fmt::print(source,
             R"(    out << "{{";)""\n"

--- a/generator/tree-gen-cpp.cpp
+++ b/generator/tree-gen-cpp.cpp
@@ -1137,14 +1137,6 @@ void generate_json_dumper_class(
             node->title_case_name);
         fmt::print(source, "    out << \"{{\";\n");
         bool first_attrib = true;
-        if (!source_location.empty()) {
-            fmt::print(source,
-                R"(    if (auto loc = node.get_annotation_ptr<{}>()) {{)""\n"
-                R"(        out << "\"source_location\":\"" << *loc << "\"";)""\n"
-                R"(    }})""\n",
-                source_location);
-            first_attrib = false;
-        }
         if (!attributes.empty()) {
             for (auto &attrib : attributes) {
                 if (!first_attrib) {
@@ -1236,6 +1228,15 @@ void generate_json_dumper_class(
 
                 }
             }
+        }
+        if (!source_location.empty()) {
+            fmt::print(source, "    if (auto loc = node.get_annotation_ptr<{}>()) {{\n", source_location);
+            if (!attributes.empty()) {
+                fmt::print(source, "    out << \",\";\n");
+            }
+            fmt::print(source,
+                   R"(        out << "\"source_location\":\"" << *loc << "\"";)""\n"
+                   R"(    }})""\n");
         }
         fmt::print(source, R"(    out << "}}";)""\n");
         fmt::print(source,

--- a/include/tree-base.cpp.inc
+++ b/include/tree-base.cpp.inc
@@ -71,7 +71,7 @@ void IdentifierMap::restore_links() const {
  * NotWellFormed exception is thrown.
  */
 void Completable::find_reachable(PointerMap &map) const {
-    (void)map;
+    (void) map;
 }
 
 /**
@@ -85,7 +85,7 @@ void Completable::find_reachable(PointerMap &map) const {
  * If not complete, a NotWellFormed exception is thrown.
  */
 void Completable::check_complete(const PointerMap &map) const {
-    (void)map;
+    (void) map;
 }
 
 /**

--- a/include/tree-base.hpp.inc
+++ b/include/tree-base.hpp.inc
@@ -1473,7 +1473,7 @@ public:
      * NotWellFormed exception is thrown.
      */
     void find_reachable(PointerMap &map) const override {
-        (void)map;
+        (void) map;
     }
 
     /**
@@ -1515,7 +1515,7 @@ protected:
      * actual tree yet.
      */
     void deserialize(const cbor::MapReader &map, IdentifierMap &ids) {
-        (void)ids;
+        (void) ids;
         // Note: this is in a function rather than in the constructor, because
         // serdes_edge_type() would map to the base class if we just chain
         // constructors, and we don't want to repeat this whole mess for Many.


### PR DESCRIPTION
`tree-gen-cpp.cpp`:
- Added `generate_json_dumper_class`.
- Fixed some 'unused parameter' compiler erros.
- Fixed some documentation tests.

`CMakeLists.txt`: added extra compile options.

`examples/{directory,interpreter}/main.cpp`: added lines to exercise dump_json.